### PR TITLE
Update CODEOWNERS to reflect new ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-* @apollographql/betelgeuse @apollographql/router-core
+* @apollographql/runtime-readiness @apollographql/router-core
 
-/betelgeuse/ @apollographql/betelgeuse
+/betelgeuse/ @apollographql/runtime-readiness
 /router/ @apollographql/router-core


### PR DESCRIPTION
Moving ownership to runtime-readiness now that Betelgeuse (and also Cloud Fleet) don't exist